### PR TITLE
Add AK8 jets

### DIFF
--- a/TreeMaker/Ntuplzr/python/Validator_cfi.py
+++ b/TreeMaker/Ntuplzr/python/Validator_cfi.py
@@ -18,6 +18,7 @@ myana = cms.EDAnalyzer('Validator',
                        taus           = cms.InputTag("slimmedTausNewID"),
                        jets           = cms.InputTag("slimmedJetsPuppi"),
                        jetschs        = cms.InputTag("slimmedJets"),
+                       fatjets        = cms.InputTag("slimmedJetsAK8"),
                        met            = cms.InputTag("slimmedMETsPuppi"),
                        metpf          = cms.InputTag("slimmedMETs"),
 )


### PR DESCRIPTION
Add AK8 jets taken directly from the `slimmedJetsAK8` collection in MiniAOD, with a minimal set of info:
 - p4: pt, eta, phi, mass
 - jet substructure variables: soft-drop mass, N-subjettiness
 - DNN tagger for top, W, and Hbb. As there are no dedicated trainings for Phase2, the run2 training of ParticleNet is used.